### PR TITLE
add ironic api tempest testcases

### DIFF
--- a/ironic_tempest_plugin/services/baremetal/base.py
+++ b/ironic_tempest_plugin/services/baremetal/base.py
@@ -181,7 +181,7 @@ class BaremetalClient(rest_client.RestClient):
 
         return resp, self.deserialize(body)
 
-    def _create_request(self, resource, object_dict):
+    def _create_request(self, resource, object_dict,expected_status=http_client.CREATED):
         """Create an object of the specified type.
 
         :param resource: The name of the REST resource, e.g., 'nodes'.
@@ -195,9 +195,11 @@ class BaremetalClient(rest_client.RestClient):
         uri = self._get_uri(resource)
 
         resp, body = self.post(uri, body=body)
-        self.expected_success(http_client.CREATED, resp.status)
-
-        return resp, self.deserialize(body)
+        self.expected_success(expected_status, resp.status)
+        if body:
+           return resp,self.deserialize(body)
+        else:
+           return resp,body
 
     def _create_request_no_response_body(self, resource, object_dict):
         """Create an object of the specified type.

--- a/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
+++ b/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
@@ -749,7 +749,7 @@ class BaremetalClient(base.BaremetalClient):
     def call_method_by_driver(self,driver_name,method_name):
         """.
 
-        :param driver_name: The name of th driver.
+        :param driver_name: The name of the driver.
         :param method_name: The name of the method.
 
         """

--- a/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
+++ b/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
@@ -708,7 +708,6 @@ class BaremetalClient(base.BaremetalClient):
         :param method_name: The name of the method.
 
         """
- #       resp, body = self._list_request('nodes/%s/vendor_passthru?method=%s' % (node_uuid,method_name))
         body = {'bar': 'fake'}
         resp, body = self._create_request('nodes/%s/vendor_passthru?method=%s' % (node_uuid,method_name),
                                           body, expected_status=202)
@@ -750,7 +749,7 @@ class BaremetalClient(base.BaremetalClient):
     def call_method_by_driver(self,driver_name,method_name):
         """.
 
-        :param driver_name: The name of the driver.
+        :param driver_name: The name of th driver.
         :param method_name: The name of the method.
 
         """

--- a/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
+++ b/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
@@ -420,6 +420,10 @@ class BaremetalClient(base.BaremetalClient):
                            'properties/local_gb',
                            'properties/memory_mb',
                            'driver',
+                           'driver_info/ipmi_address',
+                           'driver_info/ipmi_password',
+                           'driver_info/ipmi_username',
+                           'driver_info/ipmi_port',
                            'bios_interface',
                            'deploy_interface',
                            'rescue_interface',
@@ -610,6 +614,159 @@ class BaremetalClient(base.BaremetalClient):
         resp, body = self._put_request('nodes/%s/states/console' % node_uuid,
                                        enabled)
         self.expected_success(http_client.ACCEPTED, resp.status)
+        return resp, body
+
+    @base.handle_errors
+    def set_node_maintenance(self, node_uuid, reason=None):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+        :param enabled: Boolean value; whether to enable or disable the
+                        console.
+
+        """
+        reason = {"reason": None}
+        resp, body = self._put_request('nodes/%s/maintenance' % node_uuid, reason)
+
+        self.expected_success(http_client.ACCEPTED, resp.status)
+        return resp, body
+
+    @base.handle_errors
+    def clear_node_maintenance(self, node_uuid):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+        :param enabled: Boolean value; whether to enable or disable the
+                        console.
+
+        """
+        resp,body = self._delete_request('nodes/%s/maintenance' % node_uuid, {}, expected_status=202)
+
+        return resp,body
+
+    @base.handle_errors
+    def inject_node_nmi(self, node_uuid):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+        :param enabled: Boolean value; whether to enable or disable the
+                        console.
+
+        """
+        resp, body = self._put_request('nodes/%s/management/inject_nmi' % node_uuid,{})
+        return resp, body
+
+    @base.handle_errors
+    def list_volume_resource_by_node(self, node_uuid):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+        :param enabled: Boolean value; whether to enable or disable the
+                        console.
+
+        """
+        resp, body = self._list_request('nodes/%s/volume' % node_uuid)
+        return resp, body
+
+    @base.handle_errors
+    def list_volume_connectors_by_node(self, node_uuid):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+        :param enabled: Boolean value; whether to enable or disable the
+                        console.
+
+        """
+        resp, body = self._list_request('nodes/%s/volume/connectors' % node_uuid)
+        return resp, body
+
+    @base.handle_errors
+    def list_volume_targets_by_node(self, node_uuid):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+
+        """
+        resp, body = self._list_request('nodes/%s/volume/targets' % node_uuid)
+        return resp, body
+
+    @base.handle_errors
+    def list_methods_by_node(self, node_uuid):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+
+        """
+        resp, body = self._list_request('nodes/%s/vendor_passthru/methods' % node_uuid)
+        return resp, body
+
+    @base.handle_errors
+    def call_method_by_node(self, node_uuid,method_name):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+        :param method_name: The name of the method.
+
+        """
+ #       resp, body = self._list_request('nodes/%s/vendor_passthru?method=%s' % (node_uuid,method_name))
+        body = {'bar': 'fake'}
+        resp, body = self._create_request('nodes/%s/vendor_passthru?method=%s' % (node_uuid,method_name),
+                                          body, expected_status=202)
+        return resp, body
+
+    @base.handle_errors
+    def agent_lookup(self,node_uuid=None, addresses=None):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+
+        """
+        resp, body = self._list_request('lookup?node_uuid=%s&&addresses=%s' % (node_uuid, addresses))
+        return resp, body
+
+    @base.handle_errors
+    def agent_heart_beat(self,node_uuid=None):
+        """.
+
+        :param node_uuid: Unique identifier of the node in UUID format.
+
+        """
+        callback_url={"callback_url":"/v1/heartbeat"}
+        resp, body = self._create_request('heartbeat/%s' % node_uuid,callback_url,
+                                          expected_status=202)
+        return resp, body
+
+    @base.handle_errors
+    def list_methods_by_driver(self,driver_name):
+        """.
+
+        :param driver_name: The name of the driver.
+
+        """
+        resp, body = self._list_request('drivers/%s/vendor_passthru/methods' % driver_name)
+        return resp, body
+
+    @base.handle_errors
+    def call_method_by_driver(self,driver_name,method_name):
+        """.
+
+        :param driver_name: The name of the driver.
+        :param method_name: The name of the method.
+
+        """
+        body = {'bar': 'fake'}
+        resp, body = self._create_request('drivers/%s/vendor_passthru?method=%s' % (driver_name,method_name),
+                                          body, expected_status=202)
+        return resp, body
+
+    @base.handle_errors
+    def validate_node(self,node_uuid):
+        """.
+
+        :node_uuid: The uuid of the node.
+
+        """
+        resp, body = self._list_request('nodes/%s/validate' % node_uuid)
         return resp, body
 
     @base.handle_errors

--- a/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
+++ b/ironic_tempest_plugin/services/baremetal/v1/json/baremetal_client.py
@@ -746,19 +746,6 @@ class BaremetalClient(base.BaremetalClient):
         return resp, body
 
     @base.handle_errors
-    def call_method_by_driver(self,driver_name,method_name):
-        """.
-
-        :param driver_name: The name of the driver.
-        :param method_name: The name of the method.
-
-        """
-        body = {'bar': 'fake'}
-        resp, body = self._create_request('drivers/%s/vendor_passthru?method=%s' % (driver_name,method_name),
-                                          body, expected_status=202)
-        return resp, body
-
-    @base.handle_errors
     def validate_node(self,node_uuid):
         """.
 

--- a/ironic_tempest_plugin/tests/api/admin/base.py
+++ b/ironic_tempest_plugin/tests/api/admin/base.py
@@ -28,7 +28,7 @@ CONF = config.CONF
 # will require passing driver-specific data to Tempest (addresses,
 # credentials, etc).  Until then, only support testing against the fake driver,
 # which has no external dependencies.
-SUPPORTED_DRIVERS = ['fake', 'fake-hardware']
+SUPPORTED_DRIVERS = ['fake', 'fake-hardware', 'ipmi', 'agent_ipmitool']
 
 # NOTE(jroll): resources must be deleted in a specific order, this list
 # defines the resource types to clean up, and the correct order.
@@ -163,7 +163,7 @@ class BaseBaremetalTest(api_version_utils.BaseMicroversionTest,
     @classmethod
     @creates('node')
     def create_node(cls, chassis_id, cpu_arch='x86_64', cpus=8, local_gb=10,
-                    memory_mb=4096, resource_class=None):
+                    memory_mb=4096, resource_class=None, **kwargs):
         """Wrapper utility for creating test baremetal nodes.
 
         :param chassis_id: The unique identifier of the chassis.
@@ -175,11 +175,14 @@ class BaseBaremetalTest(api_version_utils.BaseMicroversionTest,
         :return: A tuple with the server response and the created node.
 
         """
+        if 'driver' not in kwargs or not kwargs.get('driver'):
+            kwargs['driver'] = cls.driver
         resp, body = cls.client.create_node(chassis_id, cpu_arch=cpu_arch,
                                             cpus=cpus, local_gb=local_gb,
                                             memory_mb=memory_mb,
-                                            driver=cls.driver,
-                                            resource_class=resource_class)
+#                                            driver=cls.driver,
+                                            resource_class=resource_class,
+                                            kwrags=kwargs)
 
         return resp, body
 

--- a/ironic_tempest_plugin/tests/api/admin/test_nodes.py
+++ b/ironic_tempest_plugin/tests/api/admin/test_nodes.py
@@ -193,7 +193,6 @@ class TestNodes(base.BaseBaremetalTest):
     @decorators.idempotent_id('f63b6289-1168-4426-1234-0d5b7eb87c06')
     def test_list_methods_by_node(self):
         resp, body = self.client.list_methods_by_node(self.node['uuid'])
-        print "-------body=%s-------" % body
         self.assertEqual(200,int(resp['status']))
 
     @decorators.idempotent_id('f63b6289-1168-4426-8cfe-0d5b7eb87c06')
@@ -217,13 +216,6 @@ class TestNodes(base.BaseBaremetalTest):
         driver_name='fake'
         resp, body = self.client.list_methods_by_driver(driver_name)
         self.assertEqual(200,int(resp['status']))
-
-    @decorators.idempotent_id('f63b6289-abcd-1234-8cfe-0d6b7eb83456')
-    def test_call_method_by_driver(self):
-        driver_name = 'fake'
-        method_name = 'second_method'
-        resp, body = self.client.call_method_by_driver(driver_name,method_name)
-        #self.assertEqual(202,int(resp['status']))
 
     @decorators.idempotent_id('f63b6289-bcde-1234-8cfe-0d6b7eb83456')
     def test_list_nodes_detail(self):

--- a/ironic_tempest_plugin/tests/api/admin/test_nodes.py
+++ b/ironic_tempest_plugin/tests/api/admin/test_nodes.py
@@ -27,6 +27,8 @@ CONF = config.CONF
 class TestNodes(base.BaseBaremetalTest):
     """Tests for baremetal nodes."""
 
+    min_microversion = '1.34'
+
     def setUp(self):
         super(TestNodes, self).setUp()
 
@@ -157,6 +159,85 @@ class TestNodes(base.BaseBaremetalTest):
         self.client.set_console_mode(self.node['uuid'], True)
         waiters.wait_for_bm_node_status(self.client, self.node['uuid'],
                                         'console_enabled', True)
+
+    @decorators.idempotent_id('80504575-9b21-4673-92d1-143b948f9439')
+    def test_set_node_maintenance(self):
+        resp, body = self.client.set_node_maintenance(self.node['uuid'], None)
+        self.assertEqual(202, int(resp['status']))
+        _, loaded_node = self.client.show_node(self.node['uuid'])
+        self.assertEqual(True, loaded_node['maintenance'])
+
+    @decorators.idempotent_id('80504575-9b21-4673-64d1-143b948f9439')
+    def test_clear_node_maintenance(self):
+        resp,body = self.client.clear_node_maintenance(self.node['uuid'])
+        self.assertEqual(202, int(resp['status']))
+        _, loaded_node = self.client.show_node(self.node['uuid'])
+        self.assertEqual(False, loaded_node['maintenance'])
+
+    @decorators.idempotent_id('80504534-9b21-2573-64d1-143b948f9439')
+    def test_inject_node_nmi(self):
+        param= {'ipmi_address': '127.0.0.1',
+                'ipmi_username': 'admin',
+                'ipmi_password': 'password',
+                'ipmi_port': 6230}
+        patch = [{'path': '/driver_info/%s' % name,
+                  'op': 'add',
+                  'value': param[name]} for name in param]
+        self.client.update_node(self.node['uuid'], patch)
+
+        _, body = self.client.update_node(
+            self.node['uuid'], driver='ipmi')
+        resp,body = self.client.inject_node_nmi(body['uuid'])
+        self.assertEqual(204, int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-1168-4426-1234-0d5b7eb87c06')
+    def test_list_methods_by_node(self):
+        resp, body = self.client.list_methods_by_node(self.node['uuid'])
+        print "-------body=%s-------" % body
+        self.assertEqual(200,int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-1168-4426-8cfe-0d5b7eb87c06')
+    def test_call_method_by_node(self):
+        method_name = 'first_method'
+        resp, body = self.client.call_method_by_node(self.node['uuid'],method_name)
+        self.assertEqual(202,int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-1168-1234-8cfe-0d6b7eb87c06')
+    def test_agent_lookup(self):
+        resp, body = self.client.agent_lookup(self.node['uuid'])
+        self.assertEqual(200,int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-1234-1234-8cfe-0d6b7eb87c06')
+    def test_agent_heart_beat(self):
+        resp, body = self.client.agent_heart_beat(self.node['uuid'])
+        self.assertEqual(202,int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-1168-1234-8cfe-0d6b7eb83456')
+    def test_list_methods_by_driver(self):
+        driver_name='fake'
+        resp, body = self.client.list_methods_by_driver(driver_name)
+        self.assertEqual(200,int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-abcd-1234-8cfe-0d6b7eb83456')
+    def test_call_method_by_driver(self):
+        driver_name = 'fake'
+        method_name = 'second_method'
+        resp, body = self.client.call_method_by_driver(driver_name,method_name)
+        #self.assertEqual(202,int(resp['status']))
+
+    @decorators.idempotent_id('f63b6289-bcde-1234-8cfe-0d6b7eb83456')
+    def test_list_nodes_detail(self):
+        """Detailed list of all existing nodes."""
+        resp, body = self.client.list_nodes_detail()
+        self.assertIn(self.node['uuid'],
+                      [i['uuid'] for i in body['nodes']])
+        self.assertEqual(200,int(resp['status']))
+
+    @decorators.idempotent_id('f63b5678-bcde-1234-8cfe-0d6b7eb83456')
+    def test_validate_node(self):
+        """validate node"""
+        resp, body = self.client.validate_node(self.node['uuid'])
+        self.assertEqual(200,int(resp['status']))
 
     @decorators.idempotent_id('b02a4f38-5e8b-44b2-aed2-a69a36ecfd69')
     def test_get_node_by_instance_uuid(self):

--- a/ironic_tempest_plugin/tests/api/admin/test_volume_connector.py
+++ b/ironic_tempest_plugin/tests/api/admin/test_volume_connector.py
@@ -119,7 +119,6 @@ class TestVolumeConnector(base.BaseBaremetalTest):
         """List volume connectors."""
         params={'type':'iqn','connector_id':'iqn.2018-09.org.openstack:01:d8a52832c3f','extra':{}}
         resp, volume_connector = self.create_volume_connector(self.node['uuid'],**params)
-        print('-------resp.status=%s----------',resp['status'])
         _, body = self.client.list_volume_connectors_by_node(self.node['uuid'])
         self.assertIn(volume_connector['uuid'],
                       [p['uuid'] for p in body['connectors']])

--- a/ironic_tempest_plugin/tests/api/admin/test_volume_connector.py
+++ b/ironic_tempest_plugin/tests/api/admin/test_volume_connector.py
@@ -21,6 +21,7 @@ from ironic_tempest_plugin.tests.api.admin import api_microversion_fixture
 from ironic_tempest_plugin.tests.api.admin import base
 
 
+
 class TestVolumeConnector(base.BaseBaremetalTest):
     """Basic test cases for volume connector."""
 
@@ -55,6 +56,15 @@ class TestVolumeConnector(base.BaseBaremetalTest):
             self.node['uuid'],
             type=self.volume_connector['type'],
             connector_id=self.volume_connector['connector_id'])
+
+    @decorators.idempotent_id('3c3cbf45-488a-4386-a811-bf0aa2589c69')
+    def test_create_volume_connector(self):
+        """Create a volume connector.
+
+        """
+        params={'type':'iqn','connector_id':'iqn.2017-07.org.openstack:01:d9a51732c3f','extra':{}}
+        resp,body=self.create_volume_connector(self.node['uuid'],**params)
+        self.assertEqual(201,int(resp['status']))
 
     @decorators.idempotent_id('5795f816-0789-42e6-bb9c-91b4876ad13f')
     def test_delete_volume_connector(self):
@@ -103,6 +113,16 @@ class TestVolumeConnector(base.BaseBaremetalTest):
                       [i['type'] for i in body['connectors']])
         self.assertIn(self.volume_connector['connector_id'],
                       [i['connector_id'] for i in body['connectors']])
+
+    @decorators.idempotent_id('a4725698-e164-4ee5-96a0-66119a35f783')
+    def test_list_volume_connectors_by_node(self):
+        """List volume connectors."""
+        params={'type':'iqn','connector_id':'iqn.2018-09.org.openstack:01:d8a52832c3f','extra':{}}
+        resp, volume_connector = self.create_volume_connector(self.node['uuid'],**params)
+        print('-------resp.status=%s----------',resp['status'])
+        _, body = self.client.list_volume_connectors_by_node(self.node['uuid'])
+        self.assertIn(volume_connector['uuid'],
+                      [p['uuid'] for p in body['connectors']])
 
     @decorators.idempotent_id('1d0459ad-01c0-46db-b930-7301bc2a3c98')
     def test_list_with_limit(self):

--- a/ironic_tempest_plugin/tests/api/admin/test_volume_resource.py
+++ b/ironic_tempest_plugin/tests/api/admin/test_volume_resource.py
@@ -1,0 +1,52 @@
+# Copyright 2017 FUJITSU LIMITED
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+from tempest.lib.common.utils import data_utils
+from tempest.lib import decorators
+from tempest.lib import exceptions as lib_exc
+
+from ironic_tempest_plugin.tests.api.admin import api_microversion_fixture
+from ironic_tempest_plugin.tests.api.admin import base
+
+
+class TestVolumeResource(base.BaseBaremetalTest):
+
+    min_microversion = '1.32'
+    extra = {'key1': 'value1', 'key2': 'value2'}
+
+    def setUp(self):
+        super(TestVolumeResource, self).setUp()
+        self.useFixture(
+            api_microversion_fixture.APIMicroversionFixture(
+                self.min_microversion))
+        _, self.chassis = self.create_chassis()
+        _, self.node = self.create_node(self.chassis['uuid'])
+        _, self.volume_connector = self.create_volume_connector(
+            self.node['uuid'], type='iqn',
+            connector_id=data_utils.rand_name('connector_id'),
+            extra=self.extra)
+        _, self.volume_target = self.create_volume_target(
+            self.node['uuid'], volume_type=data_utils.rand_name('volume_type'),
+            volume_id=data_utils.rand_name('volume_id'),
+            boot_index=10,
+            extra=self.extra)
+
+
+    @decorators.idempotent_id('a4725778-e164-4ee5-96a0-66119a35f784')
+    def test_list_volume_resource_by_node(self):
+        """List volume resource by node."""
+        _, body = self.client.list_volume_resource_by_node(self.node['uuid'])
+       
+

--- a/ironic_tempest_plugin/tests/api/admin/test_volume_target.py
+++ b/ironic_tempest_plugin/tests/api/admin/test_volume_target.py
@@ -58,6 +58,15 @@ class TestVolumeTarget(base.BaseBaremetalTest):
             volume_id=data_utils.rand_name('volume_id'),
             boot_index=self.volume_target['boot_index'])
 
+    @decorators.idempotent_id('da5c37d5-68cc-499f-b8ab-3048b87d3bca')
+    def test_create_volume_target(self):
+        """Create a volume target.
+
+        """
+        params={'volume_type':'iscsi','boot_index':0,'volume_id':'04452bed-5367-4202-8bf5-de4335ac56d2'}
+        resp,body=self.create_volume_target(self.node['uuid'],**params)
+        self.assertEqual(201,int(resp['status']))
+
     @decorators.idempotent_id('ea3a9b2e-8971-4830-9274-abaf0239f1ce')
     def test_delete_volume_target(self):
         """Delete a volume target."""
@@ -101,6 +110,15 @@ class TestVolumeTarget(base.BaseBaremetalTest):
         self.assertIn(self.volume_target['volume_id'],
                       [i['volume_id'] for i in body['targets']])
 
+    @decorators.idempotent_id('ae99a975-d93c-4324-9cdc-41d89e3a659f')
+    def test_list_volume_targets_by_node(self):
+        """List volume targets by node"""
+        params={'volume_type':'iscsi','boot_index':0,'volume_id':'04456bed-5367-4202-8bf5-de4335ac56d3'}
+        resp, volume_target = self.create_volume_target(self.node['uuid'],**params)
+        _,body = self.client.list_volume_targets_by_node(self.node['uuid'])
+        self.assertIn(volume_target['uuid'],
+                      [p['uuid'] for p in body['targets']])
+ 
     @decorators.idempotent_id('9da25447-0370-4b33-9c1f-d4503f5950ae')
     def test_list_with_limit(self):
         """List volume targets with limit."""


### PR DESCRIPTION
你好，我是苏研云计算产品部-胡文辉，亚军哥最近给我分配了任务，开发ironic API文档中社区没有的testcases，我在我的devstack P版环境中测试tox -e api,总共166个用例，passed 162,skipped:4,fail:0（原环境中总共151个用例，passed147,skipped:4,failed:0）。有空的话帮忙review一下，谢谢！



备注：(1)(测试test_nodes.py中的test_agent_lookup和test_agent_heart_beat两个用例时，建议将/etc/ironic/ironic.conf中的[api]增加配置项restrtict_lookup=false，否则可能会报错
(2)在ironic-tempest-plugin/ironic_tempest_plugin/services/baremetal/base.py文件中，在方法_create_request中增加了传入参数，expected——status，对于大多数POST请求，大多数响应正常的返回码是http_client.CREATED（201），但有少数的POST请求其响应的正常返回码是202，如Agent_Heartbeat,建议参考https://github.com/openstack/ironic/blob/stable/pike/api-ref/source/baremetal-api-v1-misc.inc